### PR TITLE
New option called ToStandardError

### DIFF
--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -74,10 +74,14 @@
 #if defined(__FreeBSD__)
 #   define _ELPP_OS_FREEBSD 1
 #endif
+// Solaris
+#if defined(__sun)
+#   define _ELPP_OS_SOLARIS 1
+#endif
 // Unix
-#if ((_ELPP_OS_LINUX || _ELPP_OS_MAC || _ELPP_OS_FREEBSD) && (!_ELPP_OS_WINDOWS))
+#if ((_ELPP_OS_LINUX || _ELPP_OS_MAC || _ELPP_OS_FREEBSD || _ELPP_OS_SOLARIS) && (!_ELPP_OS_WINDOWS))
 #   define _ELPP_OS_UNIX 1
-#endif  // ((_ELPP_OS_LINUX || _ELPP_OS_MAC || _ELPP_OS_FREEBSD) && (!_ELPP_OS_WINDOWS))
+#endif  // ((_ELPP_OS_LINUX || _ELPP_OS_MAC || _ELPP_OS_FREEBSD || _ELPP_OS_SOLARIS) && (!_ELPP_OS_WINDOWS))
 // Android
 #if defined(__ANDROID__)
 #   define _ELPP_OS_ANDROID 1

--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -4227,13 +4227,13 @@ private:
                 if (ELPP->hasFlag(LoggingFlag::ColoredTerminalOutput))
                     m_data->logMessage()->logger()->logBuilder()->convertToColoredOutput(&logLine, m_data->logMessage()->level());
                 ELPP_COUT << ELPP_COUT_LINE(logLine);
-                if (EPP_COUT_FAILBIT) {
+                if (ELPP_COUT_FAILBIT) {
                   ELPP_COUT_CLEAR;
                 }
             }
             if (m_data->logMessage()->logger()->m_typedConfigurations->toStandardError(m_data->logMessage()->level())) {
                 ELPP_CERR << ELPP_CERR_LINE(logLine);
-                if (EPP_CERR_FAILBIT) {
+                if (ELPP_CERR_FAILBIT) {
                   ELPP_CERR_CLEAR;
                 }
             }

--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -428,6 +428,7 @@ namespace type {
 #undef ELPP_LITERAL
 #undef ELPP_STRLEN
 #undef ELPP_COUT
+#undef ELPP_CERR
 #if defined(_ELPP_UNICODE)
 #   define ELPP_LITERAL(txt) L##txt
 #   define ELPP_STRLEN wcslen
@@ -436,6 +437,13 @@ namespace type {
 #   else
 #      define ELPP_COUT std::wcout
 #   endif  // defined ELPP_CUSTOM_COUT
+#   if defined(_ELPP_ERROR_TO_CERR)
+#      if defined ELPP_CUSTOM_CERR
+#         define ELPP_CERR ELPP_CUSTOM_CERR
+#      else
+#         define ELPP_CERR std::wcerr
+#      endif  // defined ELPP_CUSTOM_CERR
+#   endif // _ELPP_ERROR_TO_CERR
 typedef wchar_t char_t;
 typedef std::wstring string_t;
 typedef std::wstringstream stringstream_t;
@@ -449,6 +457,11 @@ typedef std::wostream ostream_t;
 #   else
 #      define ELPP_COUT std::cout
 #   endif  // defined ELPP_CUSTOM_COUT
+#   if defined ELPP_CUSTOM_CERR
+#      define ELPP_CERR ELPP_CUSTOM_CERR
+#   else
+#      define ELPP_CERR std::cerr
+#   endif  // defined ELPP_CUSTOM_CERR
 typedef char char_t;
 typedef std::string string_t;
 typedef std::stringstream stringstream_t;
@@ -460,6 +473,11 @@ typedef std::ostream ostream_t;
 #else
 #   define ELPP_COUT_LINE(logLine) logLine << std::flush
 #endif // defined(ELPP_CUSTOM_COUT_LINE)
+#if defined(ELPP_CUSTOM_CERR_LINE)
+#   define ELPP_CERR_LINE(logLine) ELPP_CUSTOM_CERR_LINE(logLine)
+#else
+#   define ELPP_CERR_LINE(logLine) logLine << std::flush
+#endif // defined(ELPP_CUSTOM_CERR_LINE)
 typedef unsigned short EnumType;  // NOLINT
 typedef std::shared_ptr<base::Storage> StoragePointer;
 typedef int VerboseLevel;
@@ -585,7 +603,7 @@ enum class ConfigurationType : base::type::EnumType {
    /// @brief Whether or not to write corresponding log to log file
     ToFile = 2,
    /// @brief Whether or not to write corresponding level and logger log to standard output.
-   /// By standard output meaning termnal, command prompt etc
+   /// By standard output meaning terminal, command prompt etc
     ToStandardOutput = 4,
    /// @brief Determines format of logging corresponding level and logger.
     Format = 8,
@@ -604,6 +622,10 @@ enum class ConfigurationType : base::type::EnumType {
     MaxLogFileSize = 128,
    /// @brief Specifies number of log entries to hold until we flush pending log data
     LogFlushThreshold = 256,
+   /// @brief Whether or not to write corresponding level logger log to standard error.
+   /// By standard error meaning terminal std::cerr
+    ToStandardError = 512,
+
    /// @brief Represents unknown configuration
     Unknown = 1010
 };
@@ -631,6 +653,7 @@ public:
         if (configurationType == ConfigurationType::Format) return "FORMAT";
         if (configurationType == ConfigurationType::ToFile) return "TO_FILE";
         if (configurationType == ConfigurationType::ToStandardOutput) return "TO_STANDARD_OUTPUT";
+        if (configurationType == ConfigurationType::ToStandardError) return "TO_STANDARD_ERROR";
         if (configurationType == ConfigurationType::MillisecondsWidth) return "MILLISECONDS_WIDTH";
         if (configurationType == ConfigurationType::PerformanceTracking) return "PERFORMANCE_TRACKING";
         if (configurationType == ConfigurationType::MaxLogFileSize) return "MAX_LOG_FILE_SIZE";
@@ -647,6 +670,8 @@ public:
             return ConfigurationType::ToFile;
         if ((strcmp(configStr, "TO_STANDARD_OUTPUT") == 0) || (strcmp(configStr, "to_standard_output") == 0))
             return ConfigurationType::ToStandardOutput;
+        if ((strcmp(configStr, "ERROR_TO_STANDARD_ERROR") == 0) || (strcmp(configStr, "error_to_standard_error") == 0))
+            return ConfigurationType::ToStandardError;
         if ((strcmp(configStr, "FORMAT") == 0) || (strcmp(configStr, "format") == 0))
             return ConfigurationType::Format;
         if ((strcmp(configStr, "FILENAME") == 0) || (strcmp(configStr, "filename") == 0))
@@ -2586,6 +2611,7 @@ public:
 #endif  // !defined(_ELPP_NO_DEFAULT_LOG_FILE)
         setGlobally(ConfigurationType::ToFile, std::string("true"), true);
         setGlobally(ConfigurationType::ToStandardOutput, std::string("true"), true);
+        setGlobally(ConfigurationType::ToStandardError, std::string("false"), true);
         setGlobally(ConfigurationType::MillisecondsWidth, std::string("3"), true);
         setGlobally(ConfigurationType::PerformanceTracking, std::string("true"), true);
         setGlobally(ConfigurationType::MaxLogFileSize, std::string("0"), true);
@@ -2615,6 +2641,7 @@ public:
 #endif  // !defined(_ELPP_NO_DEFAULT_LOG_FILE)
         unsafeSetIfNotExist(Level::Global, ConfigurationType::ToFile, std::string("true"));
         unsafeSetIfNotExist(Level::Global, ConfigurationType::ToStandardOutput, std::string("true"));
+        unsafeSetIfNotExist(Level::Global, ConfigurationType::ToStandardError, std::string("false"));
         unsafeSetIfNotExist(Level::Global, ConfigurationType::MillisecondsWidth, std::string("3"));
         unsafeSetIfNotExist(Level::Global, ConfigurationType::PerformanceTracking, std::string("true"));
         unsafeSetIfNotExist(Level::Global, ConfigurationType::MaxLogFileSize, std::string("0"));
@@ -2880,6 +2907,10 @@ public:
         return getConfigByVal<bool>(level, &m_toStandardOutputMap, "toStandardOutput");
     }
 
+    inline bool toStandardError(Level level) {
+        return getConfigByVal<bool>(level, &m_toStandardErrorMap, "toStandardError");
+    }
+
     inline const base::LogFormat& logFormat(Level level) {
         return getConfigByRef<base::LogFormat>(level, &m_logFormatMap, "logFormat");
     }
@@ -2910,6 +2941,7 @@ private:
     std::map<Level, bool> m_toFileMap;
     std::map<Level, std::string> m_filenameMap;
     std::map<Level, bool> m_toStandardOutputMap;
+    std::map<Level, bool> m_toStandardErrorMap;
     std::map<Level, base::LogFormat> m_logFormatMap;
     std::map<Level, base::MillisecondsWidth> m_millisecondsWidthMap;
     std::map<Level, bool> m_performanceTrackingMap;
@@ -3008,6 +3040,8 @@ private:
                 setValue(conf->level(), getBool(conf->value()), &m_toFileMap);
             } else if (conf->configurationType() == ConfigurationType::ToStandardOutput) {
                 setValue(conf->level(), getBool(conf->value()), &m_toStandardOutputMap);
+            } else if (conf->configurationType() == ConfigurationType::ToStandardError) {
+                setValue(conf->level(), getBool(conf->value()), &m_toStandardErrorMap);
             } else if (conf->configurationType() == ConfigurationType::Filename) {
             // We do not yet configure filename but we will configure in another
             // loop. This is because if file cannot be created, we will force ToFile
@@ -4180,7 +4214,11 @@ private:
                 if (ELPP->hasFlag(LoggingFlag::ColoredTerminalOutput))
                     m_data->logMessage()->logger()->logBuilder()->convertToColoredOutput(&logLine, m_data->logMessage()->level());
                 ELPP_COUT << ELPP_COUT_LINE(logLine);
-             }
+            }
+            if (m_data->logMessage()->logger()->m_typedConfigurations->toStandardError(m_data->logMessage()->level())) {
+                ELPP_CERR << ELPP_CERR_LINE(logLine);
+            }
+
         }
 #if defined(_ELPP_SYSLOG)
         else if (m_data->dispatchAction() == base::DispatchAction::SysLog) {

--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -437,13 +437,11 @@ namespace type {
 #   else
 #      define ELPP_COUT std::wcout
 #   endif  // defined ELPP_CUSTOM_COUT
-#   if defined(_ELPP_ERROR_TO_CERR)
-#      if defined ELPP_CUSTOM_CERR
-#         define ELPP_CERR ELPP_CUSTOM_CERR
-#      else
-#         define ELPP_CERR std::wcerr
-#      endif  // defined ELPP_CUSTOM_CERR
-#   endif // _ELPP_ERROR_TO_CERR
+#   if defined ELPP_CUSTOM_CERR
+#      define ELPP_CERR ELPP_CUSTOM_CERR
+#   else
+#      define ELPP_CERR std::wcerr
+#   endif  // defined ELPP_CUSTOM_CERR
 typedef wchar_t char_t;
 typedef std::wstring string_t;
 typedef std::wstringstream stringstream_t;

--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -470,10 +470,10 @@ typedef std::stringstream stringstream_t;
 typedef std::fstream fstream_t;
 typedef std::ostream ostream_t;
 #endif  // defined(_ELPP_UNICODE)
-#define ELPP_COUT_FAILBIT ELPP_COUT.fail();
-#define ELPP_COUT_CLEAR ELPP_COUT.clear();
-#define ELPP_CERR_FAILBIT ELPP_CERR.fail();
-#define ELPP_CERR_CLEAR ELPP_CERR.clear();
+#define ELPP_COUT_FAILBIT ELPP_COUT.fail()
+#define ELPP_COUT_CLEAR ELPP_COUT.clear()
+#define ELPP_CERR_FAILBIT ELPP_CERR.fail()
+#define ELPP_CERR_CLEAR ELPP_CERR.clear()
 #if defined(ELPP_CUSTOM_COUT_LINE)
 #   define ELPP_COUT_LINE(logLine) ELPP_CUSTOM_COUT_LINE(logLine)
 #else

--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -470,6 +470,10 @@ typedef std::stringstream stringstream_t;
 typedef std::fstream fstream_t;
 typedef std::ostream ostream_t;
 #endif  // defined(_ELPP_UNICODE)
+#define ELPP_COUT_FAILBIT ELPP_COUT.fail();
+#define ELPP_COUT_CLEAR ELPP_COUT.clear();
+#define ELPP_CERR_FAILBIT ELPP_CERR.fail();
+#define ELPP_CERR_CLEAR ELPP_CERR.clear();
 #if defined(ELPP_CUSTOM_COUT_LINE)
 #   define ELPP_COUT_LINE(logLine) ELPP_CUSTOM_COUT_LINE(logLine)
 #else
@@ -4223,9 +4227,15 @@ private:
                 if (ELPP->hasFlag(LoggingFlag::ColoredTerminalOutput))
                     m_data->logMessage()->logger()->logBuilder()->convertToColoredOutput(&logLine, m_data->logMessage()->level());
                 ELPP_COUT << ELPP_COUT_LINE(logLine);
+                if (EPP_COUT_FAILBIT) {
+                  ELPP_COUT_CLEAR;
+                }
             }
             if (m_data->logMessage()->logger()->m_typedConfigurations->toStandardError(m_data->logMessage()->level())) {
                 ELPP_CERR << ELPP_CERR_LINE(logLine);
+                if (EPP_CERR_FAILBIT) {
+                  ELPP_CERR_CLEAR;
+                }
             }
 
         }


### PR DESCRIPTION
In the right branch this time.

I needed an option to direct logs to cerr in order to finish replacing boost logging. If this is a feature that you want to include in the project I can update the readme also (and maybe enable it by default).