### PR TITLE
fixed compiler warning on unused variable when using -DELPP_THREAD_SAFE

### DIFF
--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -1026,10 +1026,12 @@ static inline std::string getCurrentThreadId(void) {
     ss << std::this_thread::get_id();
     return ss.str();
 }
+#if ELPP_ASYNC_LOGGING
 static inline void msleep(int ms) {
     // Only when async logging enabled - this is because async is strict on compiler
-#if ELPP_ASYNC_LOGGING
     std::this_thread::sleep_for(std::chrono::milliseconds(ms));
+#else
+static inline void msleep(int) {
 #endif  // ELPP_ASYNC_LOGGING
 }
 typedef std::mutex Mutex;


### PR DESCRIPTION
With unused parameter warning enabled and ELPP_THREAD_SAFE defined, I get compiler warnings on unused parameter ms in msleep(). asynchronous logging is disabled.