### PR TITLE
Avoid mutex lock in RegisteredLoggers destructor that crashes my program at exit

### DIFF
--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -3608,7 +3608,7 @@ public:
     }
 
     virtual ~RegisteredLoggers(void) {
-        flushAll();
+        flushAllLoggers();
     }
 
     inline void setDefaultConfigurations(const Configurations& configurations) {
@@ -3663,11 +3663,7 @@ public:
     inline void flushAll(void) {
         ELPP_INTERNAL_INFO(1, "Flushing all log files");
         base::threading::ScopedLock scopedLock(lock());
-        for (base::LogStreamsReferenceMap::iterator it = m_logStreamsReference.begin();
-                it != m_logStreamsReference.end(); ++it) {
-            if (it->second.get() == nullptr) continue;
-            it->second->flush();
-        }
+        flushAllLoggers();
     }
 
 private:
@@ -3675,6 +3671,14 @@ private:
     Configurations m_defaultConfigurations;
     base::LogStreamsReferenceMap m_logStreamsReference;
     friend class el::base::Storage;
+
+    inline void flushAllLoggers(void) {
+        for (base::LogStreamsReferenceMap::iterator it = m_logStreamsReference.begin();
+                it != m_logStreamsReference.end(); ++it) {
+            if (it->second.get() == nullptr) continue;
+            it->second->flush();
+        }
+    }
 };
 /// @brief Represents registries for verbose logging
 class VRegistry : base::NoCopy, public base::threading::ThreadSafe {


### PR DESCRIPTION
This leads to a crash at program exit when ELPP_THREAD_SAFE is defined with Visual Studio 2013 on Windows 7. CTRL-C or closing terminal window are used to stop my program and both result in my program crashing.

Logged as easyloggingpp issue #261 