### PR TITLE
Use INI section format for configuration files

### DIFF
--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -784,6 +784,7 @@ namespace consts {
 #endif  // ELPP_OS_WINDOWS
     static const char* kValidLoggerIdSymbols                   =      "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._";
     static const char* kConfigurationComment                   =      "##";
+    static const char* kConfigurationLevel                     =      "*";
     static const char* kConfigurationLevelStart                =      "[";
     static const char* kConfigurationLevelEnd                  =      "]";
     static const char* kConfigurationLoggerId                  =      "--";
@@ -2708,7 +2709,8 @@ public:
         }
         static inline bool isLevel(const std::string& line) {
             return base::utils::Str::startsWith(line, std::string(base::consts::kConfigurationLevelStart))
-                   && base::utils::Str::endsWith(line, std::string(base::consts::kConfigurationLevelEnd));
+                   && base::utils::Str::endsWith(line, std::string(base::consts::kConfigurationLevelEnd)) 
+                   || base::utils::Str::startsWith(line, std::string(base::consts::kConfigurationLevel));
         }
 
         static inline bool isComment(const std::string& line) {

--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -2708,8 +2708,8 @@ public:
             }
         }
         static inline bool isLevel(const std::string& line) {
-            return base::utils::Str::startsWith(line, std::string(base::consts::kConfigurationLevelStart))
-                   && base::utils::Str::endsWith(line, std::string(base::consts::kConfigurationLevelEnd)) 
+            return (base::utils::Str::startsWith(line, std::string(base::consts::kConfigurationLevelStart))
+                   && base::utils::Str::endsWith(line, std::string(base::consts::kConfigurationLevelEnd))) 
                    || base::utils::Str::startsWith(line, std::string(base::consts::kConfigurationLevel));
         }
 

--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -784,7 +784,8 @@ namespace consts {
 #endif  // ELPP_OS_WINDOWS
     static const char* kValidLoggerIdSymbols                   =      "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._";
     static const char* kConfigurationComment                   =      "##";
-    static const char* kConfigurationLevel                     =      "*";
+    static const char* kConfigurationLevelStart                =      "[";
+    static const char* kConfigurationLevelEnd                  =      "]";
     static const char* kConfigurationLoggerId                  =      "--";
     static const std::size_t kSourceFilenameMaxLength          =      100;
     static const std::size_t kSourceLineMaxLength              =      10;
@@ -2706,7 +2707,8 @@ public:
             }
         }
         static inline bool isLevel(const std::string& line) {
-            return base::utils::Str::startsWith(line, std::string(base::consts::kConfigurationLevel));
+            return base::utils::Str::startsWith(line, std::string(base::consts::kConfigurationLevelStart))
+                   && base::utils::Str::endsWith(line, std::string(base::consts::kConfigurationLevelEnd));
         }
 
         static inline bool isComment(const std::string& line) {

--- a/test/configurations-test.h
+++ b/test/configurations-test.h
@@ -46,20 +46,20 @@ TEST(ConfigurationsTest, SetForAllLevels) {
 
 TEST(ConfigurationsTest, ParsingFromFile) {
     std::fstream confFile("/tmp/temp-test.conf", std::fstream::out);
-    confFile << " * GLOBAL:\n"
+    confFile << "[Global]\n"
     << "    FORMAT               =  %datetime %level %msg\n"
     << "* INFO:\n"
     // Following should be included in format because its inside the quotes
     << "    FORMAT               =  \"%datetime %level [%user@%host] [%func] [%loc] %msg## This should be included in format\" ## This should be excluded\n"
-    << "* DEBUG:\n"
+    << "[Global]\n"
     << "    FORMAT               =  %datetime %level [%user@%host] [%func] [%loc] %msg ## Comment before EOL char\n"
     << "## Comment on empty line\n"
     // WARNING is defined by GLOBAL
-    << "* ERROR:\n"
+    << "[Error]\n"
     << "    FORMAT               =  %datetime %level %msg\n"
     << "* FATAL:\n"
     << "    FORMAT               =  %datetime %level %msg\n"
-    << "* VERBOSE:\n"
+    << "[Verbose]\n"
     << "    FORMAT               =  %datetime %level-%vlevel %msg\n"
     << "* TRACE:\n"
     << "    FORMAT               =  %datetime %level [%func] [%loc] %msg\n";


### PR DESCRIPTION
Allows a cleaner looking conf file, and allows easy drop-in integration with QSettings. Also easy to parse with Boost for custom options.