### PR TITLE
Make easyloggingpp compile with c++17

### DIFF
--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -1297,14 +1297,14 @@ namespace el {
                                     /// @brief Trims string from start
                                     /// @param [in,out] str String to trim
                                     static inline std::string& ltrim(std::string& str) {
-                                        str.erase(str.begin(), std::find_if(str.begin(), str.end(), std::not1(std::ptr_fun<int, int>(&std::isspace))));
+                                        str.erase(str.begin(), std::find_if(str.begin(), str.end(), [](char c) { return !isspace(c); }));
                                         return str;
                                     }
                                     
                                     /// @brief Trim string from end
                                     /// @param [in,out] str String to trim
                                     static inline std::string& rtrim(std::string& str) {
-                                        str.erase(std::find_if(str.rbegin(), str.rend(), std::not1(std::ptr_fun<int, int>(&std::isspace))).base(), str.end());
+                                        str.erase(std::find_if(str.rbegin(), str.rend(), [](char c) { return !isspace(c); }).base(), str.end());
                                         return str;
                                     }
                                     

--- a/test/test.h
+++ b/test/test.h
@@ -93,7 +93,7 @@ static void cleanFile(const char* filename = logfile, el::base::type::fstream_t*
 #define BUILD_STR(strb) [&]() -> std::string { std::stringstream ssb; ssb << strb; return ssb.str(); }()
 
 static void removeFile(const char* path) {
-    system(BUILD_STR("rm -rf " << path).c_str());
+    (void)(system(BUILD_STR("rm -rf " << path).c_str())+1); // (void)(...+1) -> ignore result for gcc 4.6+
 }
 
 static const char* kSysLogIdent = "qt-gtest-proj";


### PR DESCRIPTION
c++17 removed the deprecated ptr_fun function. Replace it with a lamdda instead.