### PR TITLE
Add ELPP_DISABLE_CHECK_MACROS to not defined CHECK macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,8 @@ NOTE: All the macros either need to be defined before `#include "easylogging++"`
 | `ELPP_WINSOCK2`        | On windows system force to use `winsock2.h` instead of `winsock.h` when `WIN32_LEAN_AND_MEAN` is defined                                                                    |
 | `ELPP_CUSTOM_COUT` (advanced)     | Resolves to a value e.g, `#define ELPP_CUSTOM_COUT qDebug()` or `#define ELPP_CUSTOM_COUT std::cerr`. This will use the value for standard output (instead of using `std::cout`|
 | `ELPP_CUSTOM_COUT_LINE` (advanced) | Used with `ELPP_CUSTOM_COUT` to define how to write a log line with custom cout. e.g, `#define ELPP_CUSTOM_COUT_LINE(msg) QString::fromStdString(msg).trimmed()` |
+| `ELPP_DISABLE_CHECK_MACROS`             | Do not define the *CHECK* macros                                                                                                                  |
+| `ELPP_DISABLE_DEBUG_MACROS`             | Do not define the *DEBUG* macros                                                                                                                  |
 
  [![top] Goto Top](#table-of-contents)
  

--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -6751,6 +6751,7 @@ if (ELPP_DEBUG_LOG) C##LEVEL##_EVERY_N(el::base::Writer, n, el::base::DispatchAc
 //
 // Default Debug Only Loggers macro using CLOG(), CLOG_VERBOSE() and CVLOG() macros
 //
+#if !defined(ELPP_DISABLE_DEBUG_MACROS)
 // undef existing
 #undef DLOG
 #undef DVLOG
@@ -6775,6 +6776,8 @@ if (ELPP_DEBUG_LOG) C##LEVEL##_EVERY_N(el::base::Writer, n, el::base::DispatchAc
 #define DVLOG_AFTER_N(n, vlevel) DCVLOG_AFTER_N(n, vlevel, ELPP_CURR_FILE_LOGGER_ID)
 #define DLOG_N_TIMES(n, LEVEL) DCLOG_N_TIMES(n, LEVEL, ELPP_CURR_FILE_LOGGER_ID)
 #define DVLOG_N_TIMES(n, vlevel) DCVLOG_N_TIMES(n, vlevel, ELPP_CURR_FILE_LOGGER_ID)
+#endif // defined(ELPP_DISABLE_DEBUG_MACROS)
+#if !defined(ELPP_DISABLE_CHECK_MACROS)
 // Check macros
 #undef CCHECK
 #undef CPCHECK
@@ -6884,6 +6887,7 @@ if (ELPP_DEBUG_LOG) C##LEVEL##_EVERY_N(el::base::Writer, n, el::base::DispatchAc
 #define DCHECK_STRCASEEQ(str1, str2) DCCHECK_STRCASEEQ(str1, str2, ELPP_CURR_FILE_LOGGER_ID)
 #define DCHECK_STRCASENE(str1, str2) DCCHECK_STRCASENE(str1, str2, ELPP_CURR_FILE_LOGGER_ID)
 #define DPCHECK(condition) DCPCHECK(condition, ELPP_CURR_FILE_LOGGER_ID)
+#endif // defined(ELPP_DISABLE_CHECK_MACROS)
 #if defined(ELPP_DISABLE_DEFAULT_CRASH_HANDLING)
 #  define ELPP_USE_DEF_CRASH_HANDLER false
 #else


### PR DESCRIPTION
It is friendlier for use with code that already defines such macros.