### PR TITLE
Fix for custom datetime format in Unicode mode

### DIFF
--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -2294,7 +2294,7 @@ namespace base {
                         ++count;  // In order to remove ending brace
                         break;
                     }
-                    ss << *ptr;
+                    ss << static_cast<char>(*ptr);
                 }
                 currFormat.erase(index, count);
                 m_dateTimeFormat = ss.str();


### PR DESCRIPTION
When ELPP_UNICODE is defined, *ptr is wchar_t, but stringstream::operator<< sees it as a long, which converts it to a number. So we have to cast it to a char to ensure we get a character.