### PR TITLE
Pass LogMessage to custom formatter function

### DIFF
--- a/doc/RELEASE-NOTES-v9.90
+++ b/doc/RELEASE-NOTES-v9.90
@@ -12,6 +12,15 @@ Breaking Change: Yes
  - Fix to custom datetime format in Unicode mode
 
 ==========================
+=      NEW FEATURES      =
+==========================
+
+ - The FormatSpecifierValueResolver function passed to the CustomFormatSpecifier constructor
+   now receives `const LogMessage&` as an argument. This allows you to access message-specific context
+   (such as the verbose level) within your custom formatting function. For an example, see
+   samples/STL/custom-format-spec.cpp.
+
+==========================
 =         NOTES          =
 ==========================
 

--- a/samples/STL/custom-format-spec.cpp
+++ b/samples/STL/custom-format-spec.cpp
@@ -3,7 +3,7 @@
  //
  // Custom format specifier to demonstrate usage of el::Helpers::installCustomFormatSpecifier
  //
- // Revision 1.1
+ // Revision 1.2
  // @author mkhan3189
  //
 
@@ -11,25 +11,76 @@
 
 INITIALIZE_EASYLOGGINGPP
 
+enum ELogLevel : el::base::type::VerboseLevel {
+    kLogLevel_Off = 0,
+    kLogLevel_Error,
+    kLogLevel_Warning,
+    kLogLevel_Info,
+    kLogLevel_Debug,
+    kLogLevel_Verbose
+    };
+
+static std::map<ELogLevel, std::string> sSeverityMap {
+    { kLogLevel_Error,   "ouch!" },
+    { kLogLevel_Warning, "oops" },
+    { kLogLevel_Info,    "hey" },
+    { kLogLevel_Debug,   "debugging" },
+    { kLogLevel_Verbose, "loquacious" }
+};
+
+const char*
+getSeverity(const el::LogMessage& message) {
+    return sSeverityMap[static_cast<ELogLevel>(message.verboseLevel())].c_str();
+}
+
 class HttpRequest {
 public:
-    const char* getIp(void) {
+    const char* getIp(const el::LogMessage& message) {
         return "192.168.1.1";
     }
 };
 
 int main(void) {
+    using namespace std::placeholders;
+
     HttpRequest request;
+
     // Install format specifier
-    el::Helpers::installCustomFormatSpecifier(el::CustomFormatSpecifier("%ip_addr",  std::bind(&HttpRequest::getIp, request)));
+    el::Helpers::installCustomFormatSpecifier(el::CustomFormatSpecifier("%ip_addr",  std::bind(&HttpRequest::getIp, request, _1)));
     // Either you can do what's done above (for member function) or if you have static function you can simply say
     // el::CustomFormatSpecifier("%ip_addr", getIp)
 
     // Configure loggers
     el::Loggers::reconfigureAllLoggers(el::ConfigurationType::Format, "%datetime %level %ip_addr : %msg");
     LOG(INFO) << "This is after installed 'ip_addr' spec";
+
     // Uninstall custom format specifier
     el::Helpers::uninstallCustomFormatSpecifier("%ip_addr");
     LOG(INFO) << "This is after uninstalled";
+
+    // Install format specifier
+    el::Helpers::installCustomFormatSpecifier(el::CustomFormatSpecifier("%severity", getSeverity));
+
+    // Configure loggers
+    el::Loggers::reconfigureAllLoggers(el::ConfigurationType::Format, "%datetime{%b %d %H:%m:%s}: [%severity] %msg");
+    el::Loggers::setVerboseLevel(kLogLevel_Verbose);
+
+    VLOG(kLogLevel_Info) << "Installed 'severity' custom formatter";
+    VLOG(kLogLevel_Error) << "This is an error";
+    VLOG(kLogLevel_Warning) << "This is a warning";
+    VLOG(kLogLevel_Info) << "This is info";
+    VLOG(kLogLevel_Debug) << "This is debug";
+    VLOG(kLogLevel_Verbose) << "This is verbose";
+
+    // Uninstall custom format specifier
+    el::Helpers::uninstallCustomFormatSpecifier("%severity");
+
+    VLOG(kLogLevel_Info) << "Uninstalled 'severity' custom formatter";
+    VLOG(kLogLevel_Error) << "This is an error";
+    VLOG(kLogLevel_Warning) << "This is a warning";
+    VLOG(kLogLevel_Info) << "This is info";
+    VLOG(kLogLevel_Debug) << "This is debug";
+    VLOG(kLogLevel_Verbose) << "This is verbose";
+
     return 0;
 }

--- a/samples/STL/custom-format-spec.cpp
+++ b/samples/STL/custom-format-spec.cpp
@@ -29,13 +29,13 @@ static std::map<ELogLevel, std::string> sSeverityMap {
 };
 
 const char*
-getSeverity(const el::LogMessage& message) {
-    return sSeverityMap[static_cast<ELogLevel>(message.verboseLevel())].c_str();
+getSeverity(const el::LogMessage* message) {
+    return sSeverityMap[static_cast<ELogLevel>(message->verboseLevel())].c_str();
 }
 
 class HttpRequest {
 public:
-    const char* getIp(const el::LogMessage& message) {
+    const char* getIp(const el::LogMessage* message) {
         return "192.168.1.1";
     }
 };

--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -2439,7 +2439,7 @@ class LogFormat : public Loggable {
 };
 }  // namespace base
 /// @brief Resolving function for format specifier
-typedef std::function<const char*(const LogMessage&)> FormatSpecifierValueResolver;
+typedef std::function<const char*(const LogMessage*)> FormatSpecifierValueResolver;
 /// @brief User-provided custom format specifier
 /// @see el::Helpers::installCustomFormatSpecifier
 /// @see FormatSpecifierValueResolver
@@ -4629,7 +4629,7 @@ class DefaultLogBuilder : public LogBuilder {
          it != ELPP->customFormatSpecifiers()->end(); ++it) {
       std::string fs(it->formatSpecifier());
       base::type::string_t wcsFormatSpecifier(fs.begin(), fs.end());
-      base::utils::Str::replaceFirstWithEscape(logLine, wcsFormatSpecifier, std::string(it->resolver()(*logMessage)));
+      base::utils::Str::replaceFirstWithEscape(logLine, wcsFormatSpecifier, std::string(it->resolver()(logMessage)));
     }
 #endif  // !defined(ELPP_DISABLE_CUSTOM_FORMAT_SPECIFIERS)
     if (appendNewLine) logLine += ELPP_LITERAL("\n");

--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -2439,7 +2439,7 @@ class LogFormat : public Loggable {
 };
 }  // namespace base
 /// @brief Resolving function for format specifier
-typedef std::function<const char*(void)> FormatSpecifierValueResolver;
+typedef std::function<const char*(const LogMessage&)> FormatSpecifierValueResolver;
 /// @brief User-provided custom format specifier
 /// @see el::Helpers::installCustomFormatSpecifier
 /// @see FormatSpecifierValueResolver
@@ -4629,7 +4629,7 @@ class DefaultLogBuilder : public LogBuilder {
          it != ELPP->customFormatSpecifiers()->end(); ++it) {
       std::string fs(it->formatSpecifier());
       base::type::string_t wcsFormatSpecifier(fs.begin(), fs.end());
-      base::utils::Str::replaceFirstWithEscape(logLine, wcsFormatSpecifier, std::string(it->resolver()()));
+      base::utils::Str::replaceFirstWithEscape(logLine, wcsFormatSpecifier, std::string(it->resolver()(*logMessage)));
     }
 #endif  // !defined(ELPP_DISABLE_CUSTOM_FORMAT_SPECIFIERS)
     if (appendNewLine) logLine += ELPP_LITERAL("\n");


### PR DESCRIPTION
This allows the custom formatter to customize the formatting per message based on the message context (and by extension its logger).