### PR TITLE
Subsecond Precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Following table contains configurations supported by configuration file.
 | `To_Standard_Output`    |   bool   | Whether or not to write logs to standard output e.g, terminal or command prompt                                                                                           |
 | `Format`                |   char*  | Determines format/pattern of logging for corresponding level and logger.                                                                                                  |
 | `Filename`              |   char*  | Determines log file (full path) to write logs to for corresponding level and logger                                                                                       |
-| `Milliseconds_Width`    |   uint   | Specifies milliseconds width. Width can be within range (1-6)                                                                                                             |
+| `Subsecond_Precision`   |   uint   | Specifies subsecond precision (previously called 'milliseconds width'). Width can be within range (1-6)                                                                   |
 | `Performance_Tracking`  |   bool   | Determines whether or not performance tracking is enabled. This does not depend on logger or level. Performance tracking always uses 'performance' logger unless specified|
 | `Max_Log_File_Size`     |   size_t | If log file size of corresponding level is >= specified size, log file will be truncated.                                                                                 |
 | `Log_Flush_Threshold`   |  size_t  | Specifies number of log entries to hold until we flush pending log data                                                                                                   |
@@ -240,7 +240,7 @@ Sample Configuration File
    ENABLED              =  true
    TO_FILE              =  true
    TO_STANDARD_OUTPUT   =  true
-   MILLISECONDS_WIDTH   =  6
+   SUBSECOND_PRECISION  =  6
    PERFORMANCE_TRACKING =  true
    MAX_LOG_FILE_SIZE    =  2097152 ## 2MB - Comment starts with two hashes (##)
    LOG_FLUSH_THRESHOLD  =  100 ## Flush after every 100 logs
@@ -399,7 +399,7 @@ You can customize date/time format using following specifiers
 | `%H`            | Hour (24-hour format)                                                                                            |
 | `%m`            | Minute (zero-padded)                                                                                             |
 | `%s`            | Second (zero-padded)                                                                                             |
-| `%g`            | Milliseconds (width is configured by ConfigurationType::MillisecondsWidth)                                       |
+| `%g`            | Subsecond part (precision is configured by ConfigurationType::MillisecondsWidth)                                 |
 | `%F`            | AM/PM designation                                                                                                |
 | `%`             | Escape character                                                                                                 |
 

--- a/samples/Qt/basic/test_conf.conf
+++ b/samples/Qt/basic/test_conf.conf
@@ -5,7 +5,7 @@
     ENABLED                     =       true
     TO_FILE                     =       true
     TO_STANDARD_OUTPUT          =       true
-    MILLISECONDS_WIDTH          =       6
+    SUBSECOND_PRECISION         =       6
     PERFORMANCE_TRACKING        =       false
     MAX_LOG_FILE_SIZE               =       1024
 * WARNING:

--- a/samples/STL/logrotate.conf
+++ b/samples/STL/logrotate.conf
@@ -1,7 +1,7 @@
 -- default
 * GLOBAL:
     FORMAT = "%datetime{%Y-%M-%d %H:%m:%s.%g},%level,%thread,%msg"
-    Milliseconds_Width = 4
+    SUBSECOND_PRECISION = 4
     TO_FILE = true
     FILENAME = "logs/info.%datetime{%Y%M%d_%H%m%s}.log"
     LOG_FLUSH_THRESHOLD = 5

--- a/samples/console.conf
+++ b/samples/console.conf
@@ -4,6 +4,6 @@
 	ENABLED                 =   true
 	TO_FILE                 =   false ## Notice this
 	TO_STANDARD_OUTPUT      =   true ## Notice this
-	MILLISECONDS_WIDTH      =   3
+	SUBSECOND_PRECISION     =   3
 	PERFORMANCE_TRACKING    =   false
 	MAX_LOG_FILE_SIZE       =   2097152 ## Throw log files away after 2MB

--- a/samples/default-logger.conf
+++ b/samples/default-logger.conf
@@ -4,7 +4,7 @@
     ENABLED                 =   true
     TO_FILE                 =   true
     TO_STANDARD_OUTPUT      =   true
-    MILLISECONDS_WIDTH      =   3
+    SUBSECOND_PRECISION     =   3
     PERFORMANCE_TRACKING    =   false
     MAX_LOG_FILE_SIZE       =   2097152 ## Throw log files away after 2MB
 * DEBUG:

--- a/samples/file.conf
+++ b/samples/file.conf
@@ -4,6 +4,6 @@
 	ENABLED                 =   true
 	TO_FILE                 =   true ## Notice this
 	TO_STANDARD_OUTPUT      =   false ## Notice this
-	MILLISECONDS_WIDTH      =   3
+	SUBSECOND_PRECISION     =   3
 	PERFORMANCE_TRACKING    =   false
 	MAX_LOG_FILE_SIZE       =   2097152 ## Throw log files away after 2MB

--- a/src/easylogging++.cc
+++ b/src/easylogging++.cc
@@ -116,6 +116,7 @@ static struct ConfigurationStringToType {
   { "FORMAT", "format", ConfigurationType::Format },
   { "FILENAME", "filename", ConfigurationType::Filename },
   { "MILLISECONDS_WIDTH", "milliseconds_width", ConfigurationType::MillisecondsWidth },
+  { "SUBSECOND_PRECISION", "subsecond_precision", ConfigurationType::MillisecondsWidth },
   { "PERFORMANCE_TRACKING", "performance_tracking", ConfigurationType::PerformanceTracking },
   { "MAX_LOG_FILE_SIZE", "max_log_file_size", ConfigurationType::MaxLogFileSize },
   { "LOG_FLUSH_THRESHOLD", "log_flush_threshold", ConfigurationType::LogFlushThreshold },

--- a/src/easylogging++.cc
+++ b/src/easylogging++.cc
@@ -105,25 +105,28 @@ const char* ConfigurationTypeHelper::convertToString(ConfigurationType configura
   return "UNKNOWN";
 }
 
+static struct ConfigurationStringToType {
+  const char* upperCaseStr;
+  const char* lowerCaseStr;
+  ConfigurationType configType;
+} configStringToType[] = {
+  { "ENABLED", "enabled", ConfigurationType::Enabled },
+  { "TO_FILE", "to_file", ConfigurationType::ToFile },
+  { "TO_STANDARD_OUTPUT", "to_standard_output", ConfigurationType::ToStandardOutput },
+  { "FORMAT", "format", ConfigurationType::Format },
+  { "FILENAME", "filename", ConfigurationType::Filename },
+  { "MILLISECONDS_WIDTH", "milliseconds_width", ConfigurationType::MillisecondsWidth },
+  { "PERFORMANCE_TRACKING", "performance_tracking", ConfigurationType::PerformanceTracking },
+  { "MAX_LOG_FILE_SIZE", "max_log_file_size", ConfigurationType::MaxLogFileSize },
+  { "LOG_FLUSH_THRESHOLD", "log_flush_threshold", ConfigurationType::LogFlushThreshold },
+};
+
 ConfigurationType ConfigurationTypeHelper::convertFromString(const char* configStr) {
-  if ((strcmp(configStr, "ENABLED") == 0) || (strcmp(configStr, "enabled") == 0))
-    return ConfigurationType::Enabled;
-  if ((strcmp(configStr, "TO_FILE") == 0) || (strcmp(configStr, "to_file") == 0))
-    return ConfigurationType::ToFile;
-  if ((strcmp(configStr, "TO_STANDARD_OUTPUT") == 0) || (strcmp(configStr, "to_standard_output") == 0))
-    return ConfigurationType::ToStandardOutput;
-  if ((strcmp(configStr, "FORMAT") == 0) || (strcmp(configStr, "format") == 0))
-    return ConfigurationType::Format;
-  if ((strcmp(configStr, "FILENAME") == 0) || (strcmp(configStr, "filename") == 0))
-    return ConfigurationType::Filename;
-  if ((strcmp(configStr, "MILLISECONDS_WIDTH") == 0) || (strcmp(configStr, "milliseconds_width") == 0))
-    return ConfigurationType::MillisecondsWidth;
-  if ((strcmp(configStr, "PERFORMANCE_TRACKING") == 0) || (strcmp(configStr, "performance_tracking") == 0))
-    return ConfigurationType::PerformanceTracking;
-  if ((strcmp(configStr, "MAX_LOG_FILE_SIZE") == 0) || (strcmp(configStr, "max_log_file_size") == 0))
-    return ConfigurationType::MaxLogFileSize;
-  if ((strcmp(configStr, "LOG_FLUSH_THRESHOLD") == 0) || (strcmp(configStr, "log_flush_threshold") == 0))
-    return ConfigurationType::LogFlushThreshold;
+  for (auto& item : configStringToType) {
+    if ((strcmp(configStr, item.upperCaseStr) == 0) || (strcmp(configStr, item.lowerCaseStr) == 0)) {
+      return item.configType;
+    }
+  }
   return ConfigurationType::Unknown;
 }
 


### PR DESCRIPTION
As previously discussed, this patch will replace `MILLISECONDS_WIDTH` with `SUBSECOND_PRECISION`, but continue to recognize `MILLISECONDS_WIDTH`.

This patch has *not* changed the enumerator `ConfigurationType::MillisecondsWidth`, nor the class `MillisecondsWidth`. A related issue is that while the documentation talks about `SUBSECOND_PRECISION` now, `ConfigurationTypeHelper::convertToString` still returns `MILLISECONDS_WIDTH`. I would like to change this along with the enumerator/class change, if you are satisfied with the current changes.

The code can be further simplified if the lower-case form is not necessary. It seems the current code always converts the conf strings to upper case before invoking `ConfigurationTypeHelper::convertFromString`, and the function does not process mixed-case input. Anyway, as I do not know its history, I am leaving it as is.