### PR TITLE
Improve detection of C++11 support.

### DIFF
--- a/doc/RELEASE-NOTES-v9.90
+++ b/doc/RELEASE-NOTES-v9.90
@@ -5,7 +5,7 @@ Release type: Major
 API changes: Yes
 Breaking Change: Yes
 
-This is a major release. We have seperated header file in to `easylogging++.h` and `easylogging++.cc`. Source file (`easylogging++.cc`) encompass source to speed up compile time. . Thanks to @aparajita.
+This is a major release. We have separated header file in to `easylogging++.h` and `easylogging++.cc`. Source file (`easylogging++.cc`) encompass source to speed up compile time. Thanks to @aparajita.
 
 ==========================
 =         FIXES          =
@@ -21,7 +21,7 @@ This is a major release. We have seperated header file in to `easylogging++.h` a
    now receives `const LogMessage&` as an argument. This allows you to access message-specific context
    (such as the verbose level) within your custom formatting function. For an example, see
    samples/STL/custom-format-spec.cpp.
- - Seperated header and source file (`easylogging++.h` and `easylogging++.cc`) (issue #445)
+ - Separated header and source file (`easylogging++.h` and `easylogging++.cc`) (issue #445)
  - New `ELPP_DEFAULT_LOGGING_FLAGS` macro for setting initial logging flags
  - C++11 detection is improved, and Clang uses `std::thread` by default if it is available
 

--- a/doc/RELEASE-NOTES-v9.90
+++ b/doc/RELEASE-NOTES-v9.90
@@ -23,6 +23,7 @@ This is a major release. We have seperated header file in to `easylogging++.h` a
    samples/STL/custom-format-spec.cpp.
  - Seperated header and source file (`easylogging++.h` and `easylogging++.cc`) (issue #445)
  - New `ELPP_DEFAULT_LOGGING_FLAGS` macro for setting initial logging flags
+ - C++11 detection is improved, and Clang uses `std::thread` by default if it is available
 
 ==========================
 =         NOTES          =

--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -312,6 +312,9 @@ ELPP_INTERNAL_DEBUGGING_OUT_INFO << ELPP_INTERNAL_DEBUGGING_MSG(internalInfoStre
 #else
 #  define ELPP_VERBOSE_LOG 0
 #endif  // (!defined(ELPP_DISABLE_VERBOSE_LOGS) && (ELPP_LOGGING_ENABLED))
+#if (!(ELPP_CXX0X || ELPP_CXX11))
+#   error "C++0x (or higher) support not detected! (Is `-std=c++11' missing?)"
+#endif  // (!(ELPP_CXX0X || ELPP_CXX11))
 // Headers
 #if defined(ELPP_SYSLOG)
 #   include <syslog.h>

--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -16,6 +16,9 @@
 #ifndef EASYLOGGINGPP_H
 #define EASYLOGGINGPP_H
 // Compilers and C++0x/C++11 Evaluation
+#if __cplusplus >= 201103L
+#  define ELPP_CXX11 1
+#endif  // __cplusplus >= 201103L
 #if (defined(__GNUC__))
 #  define ELPP_COMPILER_GCC 1
 #else
@@ -27,8 +30,6 @@
 + __GNUC_PATCHLEVEL__)
 #  if defined(__GXX_EXPERIMENTAL_CXX0X__)
 #    define ELPP_CXX0X 1
-#  elif(ELPP_GCC_VERSION >= 40801)
-#    define ELPP_CXX11 1
 #  endif
 #endif
 // Visual C++
@@ -52,12 +53,9 @@
 #  define ELPP_COMPILER_CLANG 0
 #endif
 #if ELPP_COMPILER_CLANG
-#  define ELPP_CLANG_VERSION (__clang_major__ * 10000 \
-+ __clang_minor__ * 100 \
-+ __clang_patchlevel__)
-#  if (ELPP_CLANG_VERSION >= 30300)
-#    define ELPP_CXX11 1
-#  endif  // (ELPP_CLANG_VERSION >= 30300)
+#  if __has_include(<thread>)
+#    define ELPP_CLANG_HAS_THREAD
+#  endif  // __has_include(<thread>)
 #endif
 #if (defined(__MINGW32__) || defined(__MINGW64__))
 #  define ELPP_MINGW 1
@@ -233,7 +231,9 @@ ELPP_INTERNAL_DEBUGGING_OUT_INFO << ELPP_INTERNAL_DEBUGGING_MSG(internalInfoStre
 #  define STRCPY(a, b, len) strcpy(a, b)
 #endif
 // Compiler specific support evaluations
-#if ((!ELPP_MINGW && !ELPP_COMPILER_CLANG) || defined(ELPP_FORCE_USE_STD_THREAD))
+#if ((!ELPP_MINGW && \
+      !(ELPP_COMPILER_CLANG && !defined(ELPP_CLANG_HAS_THREAD))) || \
+     defined(ELPP_FORCE_USE_STD_THREAD))
 #  define ELPP_USE_STD_THREADING 1
 #else
 #  define ELPP_USE_STD_THREADING 0


### PR DESCRIPTION
1. Set ELPP_CXX11 only when the compiler’s C++ standard is C++11 or later (esp. GCC and Clang).
2. Do not use Clang version, as it is not reliable.
3. Detect and use std::thread when Clang can find the header file (this also fixes the problem that `%thread' does not output anything in Clang prior to this change).
4. Prompt the users they may forget to specify `-std=c++11' if C++11 support is not detected.