### PR TITLE
Replace remaining MillisecondsWidth and fix time issues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ You can customize date/time format using following specifiers
 | `%H`            | Hour (24-hour format)                                                                                            |
 | `%m`            | Minute (zero-padded)                                                                                             |
 | `%s`            | Second (zero-padded)                                                                                             |
-| `%g`            | Subsecond part (precision is configured by ConfigurationType::MillisecondsWidth)                                 |
+| `%g`            | Subsecond part (precision is configured by ConfigurationType::SubsecondPrecision)                               |
 | `%F`            | AM/PM designation                                                                                                |
 | `%`             | Escape character                                                                                                 |
 

--- a/samples/async/prog.cpp
+++ b/samples/async/prog.cpp
@@ -11,8 +11,8 @@ int main(int argc, char *argv[])
     // ELPP_INITIALIZE_SYSLOG("my_proc", LOG_PID | LOG_CONS | LOG_PERROR, LOG_USER);
     el::Loggers::reconfigureAllLoggers(el::ConfigurationType::ToStandardOutput, "false");
     TIMED_BLOCK(loggingPerformance, "benchmark-block") {
-        el::base::MillisecondsWidth mwidth(3);
-        std::cout << "Starting program " << el::base::utils::DateTime::getDateTime("%h:%m:%s", &mwidth) << std::endl;
+        el::base::SubsecondPrecision ssPrec(3);
+        std::cout << "Starting program " << el::base::utils::DateTime::getDateTime("%h:%m:%s", &ssPrec) << std::endl;
         int MAX_LOOP = 1000000;
         for (int i = 0; i <= MAX_LOOP; ++i) {
             LOG(INFO) << "Log message " << i;
@@ -20,7 +20,7 @@ int main(int argc, char *argv[])
         int result = MyMath::sum(1, 2);
         result = MyMath::sum(1, 3);
 
-        std::cout << "Finished program - cleaning! " << el::base::utils::DateTime::getDateTime("%h:%m:%s", &mwidth) << std::endl;
+        std::cout << "Finished program - cleaning! " << el::base::utils::DateTime::getDateTime("%h:%m:%s", &ssPrec) << std::endl;
     }
     // SYSLOG(INFO) << "This is syslog - read it from /var/log/syslog";
 

--- a/src/easylogging++.cc
+++ b/src/easylogging++.cc
@@ -103,7 +103,7 @@ const char* ConfigurationTypeHelper::convertToString(ConfigurationType configura
   if (configurationType == ConfigurationType::Format) return "FORMAT";
   if (configurationType == ConfigurationType::ToFile) return "TO_FILE";
   if (configurationType == ConfigurationType::ToStandardOutput) return "TO_STANDARD_OUTPUT";
-  if (configurationType == ConfigurationType::MillisecondsWidth) return "MILLISECONDS_WIDTH";
+  if (configurationType == ConfigurationType::SubsecondPrecision) return "SUBSECOND_PRECISION";
   if (configurationType == ConfigurationType::PerformanceTracking) return "PERFORMANCE_TRACKING";
   if (configurationType == ConfigurationType::MaxLogFileSize) return "MAX_LOG_FILE_SIZE";
   if (configurationType == ConfigurationType::LogFlushThreshold) return "LOG_FLUSH_THRESHOLD";
@@ -121,8 +121,8 @@ static struct ConfigurationStringToTypeItem configStringToTypeMap[] = {
   { "to_standard_output", ConfigurationType::ToStandardOutput },
   { "format", ConfigurationType::Format },
   { "filename", ConfigurationType::Filename },
+  { "subsecond_precision", ConfigurationType::SubsecondPrecision },
   { "milliseconds_width", ConfigurationType::MillisecondsWidth },
-  { "subsecond_precision", ConfigurationType::MillisecondsWidth },
   { "performance_tracking", ConfigurationType::PerformanceTracking },
   { "max_log_file_size", ConfigurationType::MaxLogFileSize },
   { "log_flush_threshold", ConfigurationType::LogFlushThreshold },
@@ -287,7 +287,7 @@ void Configurations::setToDefault(void) {
   setGlobally(ConfigurationType::ToFile, std::string("true"), true);
 #endif // defined(ELPP_NO_LOG_TO_FILE)
   setGlobally(ConfigurationType::ToStandardOutput, std::string("true"), true);
-  setGlobally(ConfigurationType::MillisecondsWidth, std::string("3"), true);
+  setGlobally(ConfigurationType::SubsecondPrecision, std::string("3"), true);
   setGlobally(ConfigurationType::PerformanceTracking, std::string("true"), true);
   setGlobally(ConfigurationType::MaxLogFileSize, std::string("0"), true);
   setGlobally(ConfigurationType::LogFlushThreshold, std::string("0"), true);
@@ -313,7 +313,7 @@ void Configurations::setRemainingToDefault(void) {
   unsafeSetIfNotExist(Level::Global, ConfigurationType::Filename, std::string(base::consts::kDefaultLogFile));
 #endif  // !defined(ELPP_NO_DEFAULT_LOG_FILE)
   unsafeSetIfNotExist(Level::Global, ConfigurationType::ToStandardOutput, std::string("true"));
-  unsafeSetIfNotExist(Level::Global, ConfigurationType::MillisecondsWidth, std::string("3"));
+  unsafeSetIfNotExist(Level::Global, ConfigurationType::SubsecondPrecision, std::string("3"));
   unsafeSetIfNotExist(Level::Global, ConfigurationType::PerformanceTracking, std::string("true"));
   unsafeSetIfNotExist(Level::Global, ConfigurationType::MaxLogFileSize, std::string("0"));
   unsafeSetIfNotExist(Level::Global, ConfigurationType::Format, std::string("%datetime %level [%logger] %msg"));
@@ -1615,7 +1615,7 @@ void TypedConfigurations::build(Configurations* configurations) {
     } else if (conf->configurationType() == ConfigurationType::Format) {
       setValue(conf->level(), base::LogFormat(conf->level(),
                                               base::type::string_t(conf->value().begin(), conf->value().end())), &m_logFormatMap);
-    } else if (conf->configurationType() == ConfigurationType::MillisecondsWidth) {
+    } else if (conf->configurationType() == ConfigurationType::SubsecondPrecision) {
       setValue(Level::Global,
                base::MillisecondsWidth(static_cast<int>(getULong(conf->value()))), &m_millisecondsWidthMap);
     } else if (conf->configurationType() == ConfigurationType::PerformanceTracking) {

--- a/src/easylogging++.cc
+++ b/src/easylogging++.cc
@@ -1128,7 +1128,7 @@ unsigned long long DateTime::getTimeDifference(const struct timeval& endTime, co
     return static_cast<unsigned long long>(static_cast<unsigned long long>(1000000 * endTime.tv_sec + endTime.tv_usec) -
                                            static_cast<unsigned long long>(1000000 * startTime.tv_sec + startTime.tv_usec));
   } else {
-    return static_cast<unsigned long long>((((endTime.tv_sec - startTime.tv_sec) * 1000000) +
+    return static_cast<unsigned long long>((((endTime.tv_sec - startTime.tv_sec) * 1000) +
                                             (endTime.tv_usec - startTime.tv_usec)) / 1000);
   }
 }

--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -779,7 +779,7 @@ const struct {
   double value;
   const base::type::char_t* unit;
 } kTimeFormats[] = {
-  { 1000.0f, ELPP_LITERAL("mis") },
+  { 1000.0f, ELPP_LITERAL("us") },
   { 1000.0f, ELPP_LITERAL("ms") },
   { 60.0f, ELPP_LITERAL("seconds") },
   { 60.0f, ELPP_LITERAL("minutes") },

--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -739,7 +739,7 @@ static const char  kFormatSpecifierCharValue               =      'v';
 #endif  // ELPP_VARIADIC_TEMPLATES_SUPPORTED
 static const unsigned int kMaxLogPerContainer              =      100;
 static const unsigned int kMaxLogPerCounter                =      100000;
-static const unsigned int  kDefaultMillisecondsWidth       =      3;
+static const unsigned int kDefaultSubsecondPrecision       =      3;
 static const base::type::VerboseLevel kMaxVerboseLevel     =      9;
 static const char* kUnknownUser                            =      "user";
 static const char* kUnknownHost                            =      "unknown-host";
@@ -831,25 +831,25 @@ enum class FormatFlags : base::type::EnumType {
   User = 1<<7, Host = 1<<8, LogMessage = 1<<9, VerboseLevel = 1<<10, AppName = 1<<11, ThreadId = 1<<12,
   Level = 1<<13, FileBase = 1<<14, LevelShort = 1<<15
 };
-/// @brief A milliseconds width class containing actual width and offset for date/time
-class MillisecondsWidth {
+/// @brief A subsecond precision class containing actual width and offset of the subsecond part
+class SubsecondPrecision {
  public:
-  MillisecondsWidth(void) {
-    init(base::consts::kDefaultMillisecondsWidth);
+  SubsecondPrecision(void) {
+    init(base::consts::kDefaultSubsecondPrecision);
   }
-  explicit MillisecondsWidth(int width) {
+  explicit SubsecondPrecision(int width) {
     init(width);
   }
-  bool operator==(const MillisecondsWidth& msWidth) {
-    return m_width == msWidth.m_width && m_offset == msWidth.m_offset;
+  bool operator==(const SubsecondPrecision& ssPrec) {
+    return m_width == ssPrec.m_width && m_offset == ssPrec.m_offset;
   }
   int m_width;
   unsigned int m_offset;
  private:
   void init(int width);
 };
-/// @brief Type alias of MillisecondsWidth
-typedef MillisecondsWidth SubsecondPrecision;
+/// @brief Type alias of SubsecondPrecision
+typedef SubsecondPrecision MillisecondsWidth;
 /// @brief Namespace containing utility functions/static classes used internally
 namespace utils {
 /// @brief Deletes memory safely and points to null
@@ -1151,21 +1151,21 @@ class OS : base::StaticClass {
 /// @brief Contains utilities for cross-platform date/time. This class make use of el::base::utils::Str
 class DateTime : base::StaticClass {
  public:
-  /// @brief Cross platform gettimeofday for Windows and unix platform. This can be used to determine current millisecond.
+  /// @brief Cross platform gettimeofday for Windows and unix platform. This can be used to determine current microsecond.
   ///
   /// @detail For unix system it uses gettimeofday(timeval*, timezone*) and for Windows, a seperate implementation is provided
   /// @param [in,out] tv Pointer that gets updated
   static void gettimeofday(struct timeval* tv);
 
-  /// @brief Gets current date and time with milliseconds.
+  /// @brief Gets current date and time with a subsecond part.
   /// @param format User provided date/time format
-  /// @param msWidth A pointer to base::MillisecondsWidth from configuration (non-null)
+  /// @param ssPrec A pointer to base::SubsecondPrecision from configuration (non-null)
   /// @returns string based date time in specified format.
-  static std::string getDateTime(const char* format, const base::MillisecondsWidth* msWidth);
+  static std::string getDateTime(const char* format, const base::SubsecondPrecision* ssPrec);
 
-  /// @brief Converts timeval (struct from ctime) to string using specified format and milliseconds width
+  /// @brief Converts timeval (struct from ctime) to string using specified format and subsecond precision
   static std::string timevalToString(struct timeval tval, const char* format,
-                                     const el::base::MillisecondsWidth* msWidth);
+                                     const el::base::SubsecondPrecision* ssPrec);
 
   /// @brief Formats time to get unit accordingly, units like second if > 1000 or minutes if > 60000 etc
   static base::type::string_t formatTime(unsigned long long time, base::TimestampUnit timestampUnit);
@@ -1178,7 +1178,7 @@ class DateTime : base::StaticClass {
  private:
   static struct ::tm* buildTimeInfo(struct timeval* currTime, struct ::tm* timeInfo);
   static char* parseFormat(char* buf, std::size_t bufSz, const char* format, const struct tm* tInfo,
-                           std::size_t msec, const base::MillisecondsWidth* msWidth);
+                           std::size_t msec, const base::SubsecondPrecision* ssPrec);
 };
 /// @brief Command line arguments for application if specified using el::Helpers::setArgs(..) or START_EASYLOGGINGPP(..)
 class CommandLineArgs {
@@ -1894,6 +1894,7 @@ class TypedConfigurations : public base::threading::ThreadSafe {
   const std::string& filename(Level level);
   bool toStandardOutput(Level level);
   const base::LogFormat& logFormat(Level level);
+  const base::SubsecondPrecision& subsecondPrecision(Level level = Level::Global);
   const base::MillisecondsWidth& millisecondsWidth(Level level = Level::Global);
   bool performanceTracking(Level level = Level::Global);
   base::type::fstream_t* fileStream(Level level);
@@ -1907,7 +1908,7 @@ class TypedConfigurations : public base::threading::ThreadSafe {
   std::map<Level, std::string> m_filenameMap;
   std::map<Level, bool> m_toStandardOutputMap;
   std::map<Level, base::LogFormat> m_logFormatMap;
-  std::map<Level, base::MillisecondsWidth> m_millisecondsWidthMap;
+  std::map<Level, base::SubsecondPrecision> m_subsecondPrecisionMap;
   std::map<Level, bool> m_performanceTrackingMap;
   std::map<Level, base::FileStreamPtr> m_fileStreamMap;
   std::map<Level, std::size_t> m_maxLogFileSizeMap;

--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -598,8 +598,10 @@ enum class ConfigurationType : base::type::EnumType {
   Format = 8,
   /// @brief Determines log file (full path) to write logs to for correponding level and logger
   Filename = 16,
-  /// @brief Specifies milliseconds width. Width can be within range (1-6)
-  MillisecondsWidth = 32,
+  /// @brief Specifies precision of the subsecond part. It should be within range (1-6).
+  SubsecondPrecision = 32,
+  /// @brief Alias of SubsecondPrecision (for backward compatibility)
+  MillisecondsWidth = SubsecondPrecision,
   /// @brief Determines whether or not performance tracking is enabled.
   ///
   /// @detail This does not depend on logger or level. Performance tracking always uses 'performance' logger
@@ -846,6 +848,8 @@ class MillisecondsWidth {
  private:
   void init(int width);
 };
+/// @brief Type alias of MillisecondsWidth
+typedef MillisecondsWidth SubsecondPrecision;
 /// @brief Namespace containing utility functions/static classes used internally
 namespace utils {
 /// @brief Deletes memory safely and points to null
@@ -1748,7 +1752,7 @@ class Configurations : public base::utils::RegistryWithPred<Configuration, Confi
   /// @brief Sets value of configuration for specified level.
   ///
   /// @detail Any existing configuration for specified level will be replaced. Also note that configuration types
-  /// ConfigurationType::MillisecondsWidth and ConfigurationType::PerformanceTracking will be ignored if not set for
+  /// ConfigurationType::SubsecondPrecision and ConfigurationType::PerformanceTracking will be ignored if not set for
   /// Level::Global because these configurations are not dependant on level.
   /// @param level Level to set configuration for (el::Level).
   /// @param configurationType Type of configuration (el::ConfigurationType)

--- a/test/enum-helper-test.h
+++ b/test/enum-helper-test.h
@@ -31,7 +31,7 @@ TEST(ConfigurationTypeTest, ConvertFromString) {
     EXPECT_EQ(ConfigurationType::ToStandardOutput, ConfigurationTypeHelper::convertFromString("TO_STANDARD_OUTPUT"));
     EXPECT_EQ(ConfigurationType::Format, ConfigurationTypeHelper::convertFromString("FORMAT"));
     EXPECT_EQ(ConfigurationType::Filename, ConfigurationTypeHelper::convertFromString("FILENAME"));
-    EXPECT_EQ(ConfigurationType::MillisecondsWidth, ConfigurationTypeHelper::convertFromString("MILLISECONDS_WIDTH"));
+    EXPECT_EQ(ConfigurationType::SubsecondPrecision, ConfigurationTypeHelper::convertFromString("SUBSECOND_PRECISION"));
     EXPECT_EQ(ConfigurationType::PerformanceTracking, ConfigurationTypeHelper::convertFromString("PERFORMANCE_TRACKING"));
     EXPECT_EQ(ConfigurationType::MaxLogFileSize, ConfigurationTypeHelper::convertFromString("MAX_LOG_FILE_SIZE"));
     EXPECT_EQ(ConfigurationType::LogFlushThreshold, ConfigurationTypeHelper::convertFromString("LOG_FLUSH_THRESHOLD"));
@@ -43,7 +43,7 @@ TEST(ConfigurationTypeTest, ConvertToString) {
     EXPECT_EQ("TO_STANDARD_OUTPUT", ConfigurationTypeHelper::convertToString(ConfigurationType::ToStandardOutput));
     EXPECT_EQ("FORMAT", ConfigurationTypeHelper::convertToString(ConfigurationType::Format));
     EXPECT_EQ("FILENAME", ConfigurationTypeHelper::convertToString(ConfigurationType::Filename));
-    EXPECT_EQ("MILLISECONDS_WIDTH", ConfigurationTypeHelper::convertToString(ConfigurationType::MillisecondsWidth));
+    EXPECT_EQ("SUBSECOND_PRECISION", ConfigurationTypeHelper::convertToString(ConfigurationType::SubsecondPrecision));
     EXPECT_EQ("PERFORMANCE_TRACKING", ConfigurationTypeHelper::convertToString(ConfigurationType::PerformanceTracking));
     EXPECT_EQ("MAX_LOG_FILE_SIZE", ConfigurationTypeHelper::convertToString(ConfigurationType::MaxLogFileSize));
     EXPECT_EQ("LOG_FLUSH_THRESHOLD", ConfigurationTypeHelper::convertToString(ConfigurationType::LogFlushThreshold));

--- a/test/log-format-resolution-test.h
+++ b/test/log-format-resolution-test.h
@@ -39,25 +39,25 @@ TEST(LogFormatResolutionTest, DefaultFormat) {
 
 TEST(LogFormatResolutionTest, EscapedFormat) {
 
-    MillisecondsWidth msWidth(3);
+    SubsecondPrecision ssPrec(3);
 
     LogFormat escapeTest(Level::Info, ELPP_LITERAL("%logger %datetime{%%H %H} %thread"));
     EXPECT_EQ(ELPP_LITERAL("%logger %datetime{%%H %H} %thread"), escapeTest.userFormat());
     EXPECT_EQ(ELPP_LITERAL("%logger %datetime %thread"), escapeTest.format());
     EXPECT_EQ("%%H %H", escapeTest.dateTimeFormat());
-    EXPECT_TRUE(Str::startsWith(DateTime::getDateTime(escapeTest.dateTimeFormat().c_str(), &msWidth), "%H"));
+    EXPECT_TRUE(Str::startsWith(DateTime::getDateTime(escapeTest.dateTimeFormat().c_str(), &ssPrec), "%H"));
 
     LogFormat escapeTest2(Level::Info, ELPP_LITERAL("%%logger %%datetime{%%H %H %%H} %%thread %thread %%thread"));
     EXPECT_EQ(ELPP_LITERAL("%%logger %%datetime{%%H %H %%H} %%thread %thread %%thread"), escapeTest2.userFormat());
     EXPECT_EQ(ELPP_LITERAL("%%logger %%datetime{%%H %H %%H} %%thread %thread %thread"), escapeTest2.format());
     EXPECT_EQ("", escapeTest2.dateTimeFormat()); // Date/time escaped
-    EXPECT_TRUE(Str::startsWith(DateTime::getDateTime(escapeTest.dateTimeFormat().c_str(), &msWidth), "%H"));
+    EXPECT_TRUE(Str::startsWith(DateTime::getDateTime(escapeTest.dateTimeFormat().c_str(), &ssPrec), "%H"));
 
     LogFormat escapeTest3(Level::Info, ELPP_LITERAL("%%logger %datetime{%%H %H %%H} %%thread %thread %%thread"));
     EXPECT_EQ(ELPP_LITERAL("%%logger %datetime{%%H %H %%H} %%thread %thread %%thread"), escapeTest3.userFormat());
     EXPECT_EQ(ELPP_LITERAL("%%logger %datetime %%thread %thread %thread"), escapeTest3.format());
     EXPECT_EQ("%%H %H %%H", escapeTest3.dateTimeFormat()); // Date/time escaped
-    EXPECT_TRUE(Str::startsWith(DateTime::getDateTime(escapeTest.dateTimeFormat().c_str(), &msWidth), "%H"));
+    EXPECT_TRUE(Str::startsWith(DateTime::getDateTime(escapeTest.dateTimeFormat().c_str(), &ssPrec), "%H"));
 }
 
 #endif // LOG_FORMAT_RESOLUTION_TEST_H

--- a/test/test.h
+++ b/test/test.h
@@ -65,8 +65,8 @@ static std::string tail(unsigned int n, const char* filename = logfile) {
 }
 
 static std::string getDate(const char* format = "%a %b %d, %H:%m") {
-    MillisecondsWidth msWidth(3);
-    return DateTime::getDateTime(format, &msWidth);
+    SubsecondPrecision ssPrec(3);
+    return DateTime::getDateTime(format, &ssPrec);
 }
 
 static bool fileExists(const char* filename) {


### PR DESCRIPTION
1. Use the new SubsecondPrecision enumerator.
2. Rename class MillisecondsWidth to SubsecondPrecision.
3. Add and use TypedConfigurations::subsecondPrecision.
4. Rename kDefaultMillisecondsWidth to kDefaultSubsecondPrecision.
5. Rename TypedConfigurations::m_millisecondsWidthMap to TypedConfigurations::m_subsecondPrecisionMap.
6. Update comments.
7. Fix DateTime::getTimeDifference.
8. Use the usual abbreviation of microseconds.