### PR TITLE
Fix gtest problems

### DIFF
--- a/test/build_and_run.sh
+++ b/test/build_and_run.sh
@@ -4,7 +4,7 @@
 [ -d "bin" ] || mkdir "bin"
 
 cd bin
-echo "Building...\n"
-g++ ../*.cc -std=c++11 -pthread -lgtest -I/usr/local/include/gtest/ -DELPP_NO_DEFAULT_LOG_FILE -DELPP_FEATURE_ALL -DELPP_LOGGING_FLAGS_FROM_ARG -Wall -Wextra -pedantic -pedantic-errors -Werror -Wfatal-errors -Wundef -o easyloggingpp-test && echo "Running...\n" && ./easyloggingpp-test -v
+echo "Building..."
+g++ ../*.cc -std=c++11 -pthread -lgtest -DELPP_NO_DEFAULT_LOG_FILE -DELPP_FEATURE_ALL -DELPP_LOGGING_FLAGS_FROM_ARG -Wall -Wextra -pedantic -pedantic-errors -Werror -Wfatal-errors -Wundef -o easyloggingpp-test && echo "Running..." && ./easyloggingpp-test -v
 cd ..
 echo "Completed!"

--- a/test/test.h
+++ b/test/test.h
@@ -5,7 +5,11 @@
 #ifndef TEST_HELPERS_H_
 #define TEST_HELPERS_H_
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wundef"
+#pragma GCC diagnostic ignored "-Wsign-compare"
 #include <gtest/gtest.h>
+#pragma GCC diagnostic pop
 
 #include "easylogging++.h"
 


### PR DESCRIPTION
1. Make gtest work when it is not installed to system directories, by suppressing warnings emitted from gtest.
2. Clean up the build script.